### PR TITLE
feat: implement subnet support using LPM Trie maps (#7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,9 @@ $(BUILD_DIR)/blacklist_map: src/maps/blacklist_map.c | $(BUILD_DIR)
 
 copy_script:
 	cp src/scripts/Run.sh ./Run.sh
-	cp src/scripts/Unload.sh ./Unload.sh
+ 	cp src/scripts/Unload.sh ./Unload.sh
 	chmod +x ./Run.sh
-	chmod +x ./Unload.sh
+ 	chmod +x ./Unload.sh
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/src/core/blacklist.c
+++ b/src/core/blacklist.c
@@ -1,37 +1,35 @@
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
+#include <bpf/bpf_endian.h>
 #include <linux/if_ether.h>
 #include <linux/ip.h>
 #include <linux/types.h>
 #include <linux/tcp.h>
 #include <linux/udp.h>
-#include <netinet/in.h>
-#include <string.h>
+#include <linux/in.h>
 #include "../include/blacklist_types.h"
 #include "../include/blacklist_maps.h"
 
-static int __always_inline check_and_drop(void *map, void *key)
+static __always_inline int check_and_drop(void *map, void *key)
 {
-    /*
-	void *value = bpf_map_lookup_elem(map, key); // 1 or NULL
-	if (value)
-          return 1;
-    else
-    	return 0;
-    */
     return bpf_map_lookup_elem(map, key) ? 1 : 0;
+}
+
+static __always_inline int check_lpm_drop(void *map, __u32 ip_addr) {
+    struct ipv4_lpm_key key = {
+        .prefixlen = 32,
+        .ip = ip_addr,
+    };
+
+    return bpf_map_lookup_elem(map, &key) ? 1 : 0;
 }
 
 SEC("prog")
 int blacklist(struct xdp_md *ctx)
 {
-    //void *value;
-    struct three_tuple t_tuple;
-    memset(&t_tuple, 0, sizeof(t_tuple));
-    struct ip_pair pair;
-    memset(&pair, 0, sizeof(pair));
-    struct interface_info intf;
-    memset(&intf, 0, sizeof(intf));
+    struct three_tuple t_tuple = {0};
+    struct ip_pair pair = {0};
+    struct interface_info intf = {0};
 
     void *data_end = (void *)(long)ctx->data_end;
     void *data = (void *)(long)ctx->data;
@@ -43,12 +41,12 @@ int blacklist(struct xdp_md *ctx)
         return XDP_PASS;
     }
 
-    if (eth->h_proto != htons(ETH_P_IP))
+    if (eth->h_proto != bpf_htons(ETH_P_IP))
     {
         return XDP_PASS;
     }
 
-    memcpy(intf.interface, eth->h_source, ETH_ALEN);
+    __builtin_memcpy(intf.interface, eth->h_source, ETH_ALEN);
 
     struct iphdr *iph = (struct iphdr *)(eth + 1);
 
@@ -90,6 +88,7 @@ int blacklist(struct xdp_md *ctx)
 
     if (check_and_drop(&three_tuples, &t_tuple) ||
         check_and_drop(&ip_pairs, &pair)        ||
+        check_lpm_drop(&ipv4_lpm_map, iph->saddr) ||
         check_and_drop(&source_ips, &iph->saddr)||
         check_and_drop(&destination_ips, &iph->daddr) ||
         check_and_drop(&dst_ports, &destination_port) ||

--- a/src/helpers/blacklist_config_writer.c
+++ b/src/helpers/blacklist_config_writer.c
@@ -144,16 +144,17 @@ int main(void) {
     fprintf(fp, "{\n");
     const char *f1[] = {"source_ip", "destination_ip", "destination_port", "allow"};
     const char *f2[] = {"source_ip", "destination_ip", "allow"};
-    const char *f3[] = {"destination_ip", "allow"};
+    const char *f7[] = {"subnet", "allow"};
     const char *f4[] = {"source_ip", "allow"};
+    const char *f3[] = {"destination_ip", "allow"};
     const char *f5[] = {"protocol", "allow"};
     const char *f6[] = {"interface_name", "allow"};
     struct { const char *k; int c; const char **f; } s[] = {
-        {"three_tuple", 4, f1}, {"ip_to_ip", 3, f2}, {"any_to_ip", 2, f3},
-        {"ip_to_any", 2, f4}, {"protocols", 2, f5}, {"interfaces", 2, f6}
+        {"three_tuple", 4, f1}, {"ip_to_ip", 3, f2}, {"subnets", 2, f7}, {"any_to_ip", 2, f3},
+        {"ip_to_any", 2, f4}, {"protocols", 2, f5}, {"interfaces", 2, f6},
     };
     int first = 1;
-    for (int i = 0; i < 6; i++) {
+    for (int i = 0; i < 7; i++) {
         char p[128]; snprintf(p, sizeof(p), "Add entries for '%s'?", s[i].k);
         if (get_yes_no(p)) {
             if (!first) fprintf(fp, ",\n");

--- a/src/include/blacklist_maps.h
+++ b/src/include/blacklist_maps.h
@@ -76,4 +76,13 @@ struct
     __uint(map_flags, BPF_F_NO_PREALLOC);
 } protocols SEC(".maps");
 
+struct {
+    __uint(type, BPF_MAP_TYPE_LPM_TRIE);
+    __uint(max_entries, MAX_ENTRY);
+    __type(key, struct ipv4_lpm_key);
+    __type(value, __u8);
+    __uint(pinning, LIBBPF_PIN_BY_NAME);
+    __uint(map_flags, BPF_F_NO_PREALLOC);
+} ipv4_lpm_map SEC(".maps");
+
 #endif //BLACKLIST_MAPS_H

--- a/src/include/blacklist_types.h
+++ b/src/include/blacklist_types.h
@@ -31,7 +31,7 @@ struct interface_info
 struct ipv4_lpm_key
 {
     __u32 prefixlen;
-    __u32 data;
+    __u32 ip;
 };
 
 #endif //BLACKLIST_TYPES_H

--- a/src/maps/blacklist_map.c
+++ b/src/maps/blacklist_map.c
@@ -12,11 +12,31 @@
 #define JSON_FILENAME "../blacklist_config.json"
 #define THREE_TUPLES "/sys/fs/bpf/xdp/globals/three_tuples"
 #define IP_PAIRS "/sys/fs/bpf/xdp/globals/ip_pairs"
+#define SUBNETS "/sys/fs/bpf/xdp/globals/ipv4_lpm_map"
 #define SOURCE_IPS "/sys/fs/bpf/xdp/globals/source_ips"
 #define DESTINATION_IPS "/sys/fs/bpf/xdp/globals/destination_ips"
 #define DESTINATION_PORTS "/sys/fs/bpf/xdp/globals/dst_ports"
 #define INTERFACES "/sys/fs/bpf/xdp/globals/interfaces"
 #define PROTOCOLS "/sys/fs/bpf/xdp/globals/protocols"
+
+void *parset_subnet(void *arg) {
+    int fd = bpf_obj_get(SUBNETS);
+    if (fd < 0 || !arg) return NULL;
+    json_t *val; size_t i;
+    json_array_foreach((json_t *)arg, i, val) {
+        struct ipv4_lpm_key lpm;
+        const char *subnet_str = json_string_value(json_object_get(val, "subnet"));
+        int a = json_integer_value(json_object_get(val, "allow"));
+        char ip[16] = {0};
+        int prefix = 0;
+        sscanf(subnet_str, "%15[^/]/%d", ip, &prefix);
+        inet_pton(AF_INET, ip, &lpm.ip);
+        lpm.prefixlen = prefix;
+        bpf_map_update_elem(fd, &lpm, &a, BPF_ANY);
+    }
+
+    return NULL;
+}
 
 void *parse_three_tuple(void *arg) {
     int fd = bpf_obj_get(THREE_TUPLES);
@@ -113,7 +133,8 @@ int main(void) {
     json_error_t err;
     json_t *root = json_load_file(JSON_FILENAME, 0, &err);
     if (!root) return 1;
-    pthread_t t[7];
+    pthread_t t[8];
+
     pthread_create(&t[0], NULL, parse_three_tuple, json_object_get(root, "three_tuple"));
     pthread_create(&t[1], NULL, parse_ip_to_ip, json_object_get(root, "ip_to_ip"));
     pthread_create(&t[2], NULL, parse_any_to_ip, json_object_get(root, "any_to_ip"));
@@ -121,7 +142,10 @@ int main(void) {
     pthread_create(&t[4], NULL, parse_interface, json_object_get(root, "interfaces"));
     pthread_create(&t[5], NULL, parse_ports, json_object_get(root, "ports"));
     pthread_create(&t[6], NULL, parse_protocols, json_object_get(root, "protocols"));
-    for (int i = 0; i < 7; i++) pthread_join(t[i], NULL);
+    pthread_create(&t[7], NULL, parset_subnet, json_object_get(root, "subnets"));
+
+    for (int i = 0; i < 8; i++) pthread_join(t[i], NULL);
     json_decref(root);
+
     return 0;
 }


### PR DESCRIPTION
This PR introduces support for Subnet (CIDR) blocking by migrating/expanding the current IP blocking logic to use eBPF LPM (Longest Prefix Match) Trie maps. Previously, the system only supported individual IP lookups.