### PR TITLE
[Enhancement] Add strict input validation for config_writer fields #12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,6 @@ trash/
 # Build
 build/
 blacklist_config.json
-Run.sh
-Unload.sh
 
 # .DS_Store
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,11 @@ $(BUILD_DIR)/blacklist_map: src/maps/blacklist_map.c | $(BUILD_DIR)
 
 copy_script:
 	cp src/scripts/Run.sh ./Run.sh
- 	cp src/scripts/Unload.sh ./Unload.sh
+	cp src/scripts/Unload.sh ./Unload.sh
 	chmod +x ./Run.sh
- 	chmod +x ./Unload.sh
+	chmod +x ./Unload.sh
 
 clean:
 	rm -rf $(BUILD_DIR)
 	rm -rf Run.sh
+	rm -rf Unload.sh

--- a/src/helpers/blacklist_config_writer.c
+++ b/src/helpers/blacklist_config_writer.c
@@ -3,6 +3,9 @@
 #include <string.h>
 #include <ctype.h>
 #include <stdint.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <ifaddrs.h>
 
 #define MAX_FIELD 64
 
@@ -102,6 +105,57 @@ void write_json_array(FILE *fp, const char *key, int fields, const char *field_n
                     }
                     printf("Error: Invalid port.\n");
                 }
+            } else if (strcmp(field_names[i], "subnet") == 0) {
+                while (1) {
+                    printf("Enter subnet in CIDR format (e.g., 192.168.1.0/24): ");
+                    fgets(buffer, sizeof(buffer), stdin);
+                    buffer[strcspn(buffer, "\n")] = 0;
+                    char ip_part[16]; // Only supports IPv4
+                    int prefix;
+                    if (sscanf(buffer, "%[^/]/%d", ip_part, &prefix) == 2 && prefix >= 0 && prefix <= 32) {
+                        fprintf(fp, "\"%s\"", buffer);
+                        break;
+                    }
+                    printf("Error: Invalid CIDR format or prefix range (0-32).\n");
+                }
+            } else if (strcmp(field_names[i], "interface_name") == 0) {
+                struct ifaddrs *ifaddr, *ifa;
+                int found;
+
+                while (1) {
+                    if (getifaddrs(&ifaddr) == -1) {
+                        perror("getifaddrs");
+                        break;
+                    }
+
+                    printf("Available interfaces: ");
+                    for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
+                        if (ifa->ifa_addr != NULL && ifa->ifa_addr->sa_family == AF_PACKET) {
+                            printf("%s ", ifa->ifa_name);
+                        }
+                    }
+                    printf("\nEnter the interface name: ");
+
+                    fgets(buffer, sizeof(buffer), stdin);
+                    buffer[strcspn(buffer, "\n")] = 0;
+
+                    found = 0;
+                    for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
+                        if (strcmp(ifa->ifa_name, buffer) == 0) {
+                            found = 1;
+                            break;
+                        }
+                    }
+
+                    freeifaddrs(ifaddr);
+
+                    if (found) {
+                        fprintf(fp, "\"%s\"", buffer);
+                        break;
+                    }
+
+                    printf("Error: Interface '%s' not found on this system.\n", buffer);
+                }
             } else {
                 while (1) {
                     printf("%s: ", field_names[i]);
@@ -132,7 +186,10 @@ int main(void) {
         printf("Select mode (new/reset): ");
         fgets(mode, sizeof(mode), stdin);
         mode[strcspn(mode, "\n")] = 0;
-        if (strcmp(mode, "new") == 0 || strcmp(mode, "reset") == 0) break;
+        if (strcmp(mode, "new") == 0 || strcmp(mode, "reset") == 0) {
+            break;
+        }
+        printf("Error: Invalid mode. Please select 'new' or 'reset'.\n");
     }
     if (strcmp(mode, "reset") == 0) {
         FILE *fp = fopen("../blacklist_config.json", "w");

--- a/src/scripts/Unload.sh
+++ b/src/scripts/Unload.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+BPF_DIR="/sys/fs/bpf/xdp/globals"
+
+echo "------------------------------------------------"
+echo "  XDP UNLOADER & MAP CLEANER"
+echo "------------------------------------------------"
+
+INTERFACES=$(ip -o link show | awk -F': ' '{print $2}' | grep -v "lo")
+
+echo "Available interfaces:"
+select INTERFACE in $INTERFACES "Cancel"; do
+    if [ "$INTERFACE" == "Cancel" ]; then
+        echo "Operation cancelled."
+        exit 0
+    elif [ -n "$INTERFACE" ]; then
+        echo "Selected interface: $INTERFACE"
+        break
+    else
+        echo "Invalid selection. Please try again."
+    fi
+done
+
+echo "Unloading XDP program from $INTERFACE..."
+sudo ip link set dev $INTERFACE xdpgeneric off 2>/dev/null
+
+echo "Removing pinned eBPF maps from $BPF_DIR..."
+
+MAPS=(
+    "three_tuples"
+    "ip_pairs"
+    "source_ips"
+    "destination_ips"
+    "dst_ports"
+    "interfaces"
+    "protocols"
+    "ipv4_lpm_map"
+)
+
+for MAP in "${MAPS[@]}"; do
+    if [ -f "$BPF_DIR/$MAP" ]; then
+        sudo rm "$BPF_DIR/$MAP"
+        echo "[+] Deleted: $MAP"
+    else
+        echo "[-] Not found: $MAP"
+    fi
+done
+
+echo "------------------------------------------------"
+echo "  Unload process complete."
+echo "------------------------------------------------"


### PR DESCRIPTION
This PR introduces comprehensive input validation for the config_writer component to ensure that the generated JSON configuration files are syntactically and logically correct before they are processed by the XDP user space program.

Additionally, an unload.sh script has been integrated to automate the detaching of XDP programs and ensure the clean removal of associated BPF maps from the system.